### PR TITLE
Add a composer bin definition.

### DIFF
--- a/bin/vanilla-colonize
+++ b/bin/vanilla-colonize
@@ -1,0 +1,3 @@
+#!/usr/bin/env php
+<?php
+require_once __DIR__.'/../colonize.php';

--- a/composer.json
+++ b/composer.json
@@ -12,5 +12,8 @@
     },
     "require-dev": {
 		"bobthecow/faker": "dev-master"
-	}
+	},
+    "bin": [
+      "bin/vanilla-colonize"
+    ]
 }


### PR DESCRIPTION
This will allow the script to be put in the correct place if this package is ever required somewhere else such as a composer global install.
