### PR TITLE
Fix object names in doc comments.

### DIFF
--- a/src/Table/BaseTable.php
+++ b/src/Table/BaseTable.php
@@ -11,7 +11,7 @@ abstract class BaseTable {
 
     /**
      * A reference to our object instance.
-     * @var Initvector\Colonize\Table\BaseTable
+     * @var BaseTable
      */
     protected static $instance;
 
@@ -84,7 +84,7 @@ abstract class BaseTable {
     /**
      * Return instance of current object.  Used for singleton design.
      *
-     * @return object Instance of current object.
+     * @return BaseTable Instance of current object.
      */
     public static function getInstance() {
         // Grab the name of the child class the call is performed against.

--- a/src/Table/Category.php
+++ b/src/Table/Category.php
@@ -5,7 +5,7 @@ class Category extends BaseTable {
 
     /**
      * A reference to our object instance.
-     * @var Initvector\Colonize\Table\Category
+     * @var Category
      */
     protected static $instance;
 

--- a/src/Table/Comment.php
+++ b/src/Table/Comment.php
@@ -5,7 +5,7 @@ class Comment extends BaseTable {
 
     /**
      * A reference to our object instance.
-     * @var Initvector\Colonize\Table\Comment
+     * @var Comment
      */
     protected static $instance;
 

--- a/src/Table/Discussion.php
+++ b/src/Table/Discussion.php
@@ -5,7 +5,7 @@ class Discussion extends BaseTable {
 
     /**
      * A reference to our object instance.
-     * @var Initvector\Colonize\Table\Discussion
+     * @var Discussion
      */
     protected static $instance;
 

--- a/src/Table/User.php
+++ b/src/Table/User.php
@@ -5,7 +5,7 @@ class User extends BaseTable {
 
     /**
      * A reference to our object instance.
-     * @var Initvector\Colonize\Table\User
+     * @var User
      */
     protected static $instance;
 


### PR DESCRIPTION
Classes in doc comments use the current namespace so you can remove it or have to precede the namespace with a `\`.
